### PR TITLE
Better types

### DIFF
--- a/lib/helpers/Event.d.ts
+++ b/lib/helpers/Event.d.ts
@@ -1,12 +1,12 @@
 /// <reference types="node" />
 import { WriteStream } from 'fs';
 import { ServerResponse } from 'http';
-import PokeResult from '../interfaces/PokeResult';
-interface EventManager {
+import { PokeError, PokeSuccess } from '../interfaces/PokeResult';
+interface EventManager<Result> {
     set: (eventName: string, callback: (param?: unknown) => void) => void;
-    response: (result: PokeResult) => void;
+    response: (result: PokeSuccess<Result>) => void;
     end: () => void;
-    error: (result: PokeResult) => void;
+    error: (result: PokeError<Result>) => void;
     data: (chunk: string | unknown) => void;
     stream: {
         set: (writableStream: WriteStream | ServerResponse) => void;
@@ -14,5 +14,5 @@ interface EventManager {
         end: () => void;
     };
 }
-declare const Event: () => EventManager;
+declare const Event: <Result>() => EventManager<Result>;
 export default Event;

--- a/lib/helpers/Event.js
+++ b/lib/helpers/Event.js
@@ -4,7 +4,7 @@ const Event = function () {
     // the place to stores those callbacks
     const callbacks = {};
     // return append callback methods and event callback methods
-    const manager = {
+    return {
         // set 
         set: (eventName, callback) => {
             // valid event name and callback is a function
@@ -57,6 +57,5 @@ const Event = function () {
             }
         }
     };
-    return manager;
 };
 exports.default = Event;

--- a/lib/helpers/JSON.d.ts
+++ b/lib/helpers/JSON.d.ts
@@ -1,2 +1,3 @@
 import { JSONCallback } from '../interfaces/PokeResult';
-export declare function toJson(jsonString: string, callback?: JSONCallback): void | Promise<unknown>;
+export declare function toJson<Result>(jsonString: string): Promise<Result>;
+export declare function toJson<Result>(jsonString: string, callback: JSONCallback<Result>): void;

--- a/lib/helpers/JSON.js
+++ b/lib/helpers/JSON.js
@@ -2,30 +2,28 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.toJson = void 0;
 function toJson(jsonString, callback) {
-    // is promise flag
-    const isPromise = callback === undefined;
-    try {
-        // parse json
-        const json = JSON.parse(jsonString);
-        // return a promise object
-        if (isPromise) {
+    if (callback === undefined) {
+        try {
+            // parse json
+            const json = JSON.parse(jsonString);
             // resolve with json
             return Promise.resolve(json);
         }
-        // callback with error:null, result:json
-        else {
-            callback && callback(null, json);
-        }
-    }
-    catch (error) {
-        // return a promise object
-        if (isPromise) {
+        catch (error) {
             // error occurred, reject promise
             return Promise.reject(error);
         }
-        // callback with error:null, result:json
-        else {
-            callback && callback(error, null);
+    }
+    else {
+        try {
+            // parse json
+            const json = JSON.parse(jsonString);
+            // callback with error:null, result:json
+            callback(null, json);
+        }
+        catch (error) {
+            // callback with error:null, result:json
+            callback(error, null);
         }
     }
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,5 @@
 import PokeOption from './interfaces/PokeOption';
 import PokeReturn from './interfaces/PokeReturn';
-declare function Poke(host: string, options?: PokeOption, callback?: (PokeResult: any) => void): PokeReturn;
+import PokeResult from './interfaces/PokeResult';
+declare function Poke<Body, Result>(host: string, options?: PokeOption<Body>, callback?: (pr: PokeResult<Result>) => void): PokeReturn<Result>;
 export default Poke;

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,9 +3,11 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const https = require("https");
 const http = require("http");
 const zlib = require("zlib");
+const PokeResult_1 = require("./interfaces/PokeResult");
 const Query_1 = require("./helpers/Query");
 const JSON_1 = require("./helpers/JSON");
 const Event_1 = require("./helpers/Event");
+const Protocol_1 = require("./interfaces/Protocol");
 function Poke(host, options, callback) {
     // the flag to indicate whether request is fired already
     let requestFired = false;
@@ -13,17 +15,18 @@ function Poke(host, options, callback) {
     const eventManager = Event_1.default();
     // declare PokeReturn
     const _return = {
-        req: undefined,
         promise: () => new Promise((resolve, reject) => {
             makeRequest(result => {
                 // callback based on error whether error exists
-                result.error !== undefined ? reject(result) : resolve(result);
+                // NOTE: ts seems not able to infer the reject part as PokeError but it doesn't matter in pratice
+                // NOTE: probably due to the mixing use of genric and typeguard and tsc is not smart enough for that?
+                PokeResult_1.isPokeSuccess(result) ? resolve(result) : reject(result);
             });
         }),
         abort: () => {
             var _a;
             // ensure the destroy function is available
-            if (_return.req !== undefined && ((_a = _return.req) === null || _a === void 0 ? void 0 : _a.destroy) !== undefined) {
+            if (((_a = _return.req) === null || _a === void 0 ? void 0 : _a.destroy) !== undefined) {
                 _return.req.destroy();
             }
         },
@@ -38,13 +41,15 @@ function Poke(host, options, callback) {
                 // fire request
                 makeRequest(result => {
                     // error exists AND error event listener exists
-                    if (result.error !== undefined) {
+                    if (PokeResult_1.isPokeError(result)) {
                         // return response object
                         eventManager.error(result);
                     }
                     // no error
                     else {
                         // emit respnse
+                        // NOTE: ts seems not able to infer the result type but it doesn't matter in pratice
+                        // NOTE: probably due to the mixing use of genric and typeguard and tsc is not powerful enough for that?
                         eventManager.response(result);
                         // emit end event
                         eventManager.end();
@@ -63,7 +68,7 @@ function Poke(host, options, callback) {
             // check request is fired on not
             if (requestFired === false) {
                 // start request
-                makeRequest(result => {
+                makeRequest(_ => {
                     // end stream
                     eventManager.stream.end();
                 });
@@ -78,7 +83,7 @@ function Poke(host, options, callback) {
         // get protocol
         const protocol = host.substr(0, host.indexOf(':'));
         // check protocol
-        if (!/^https?/.test(protocol)) {
+        if (!Protocol_1.isProtocol(protocol)) {
             throw new Error('url must starts with http:// or https://');
         }
         // get hostname
@@ -101,7 +106,10 @@ function Poke(host, options, callback) {
             https,
         }[protocol];
         // setup result container
-        const result = {};
+        const result = {
+            body: '',
+            json: jsonCallback => jsonCallback ? JSON_1.toJson('', jsonCallback) : JSON_1.toJson('')
+        };
         // setup request payload
         const payload = {
             method: ((_a = options === null || options === void 0 ? void 0 : options.method) === null || _a === void 0 ? void 0 : _a.toUpperCase()) || 'GET',
@@ -116,11 +124,35 @@ function Poke(host, options, callback) {
             payload.headers = Object.assign(Object.assign({}, payload.headers), { Authorization: `Basic ${Buffer.from(`${(options === null || options === void 0 ? void 0 : options.username) || ''}:${(options === null || options === void 0 ? void 0 : options.password) || ''}`).toString('base64')}` });
         }
         // prepare request and save it to pokeReturn
-        _return.req = _http === null || _http === void 0 ? void 0 : _http.request(payload, res => {
+        _return.req = _http.request(payload, res => {
             // set status code
             result.statusCode = res.statusCode;
             // does response header indicates that using gzip?
             const isGzip = /^gzip$/.test((res.headers || {})['content-encoding'] || '');
+            const prepareStream = (stream) => stream
+                // data listener
+                .on('data', d => {
+                // decompression chunk ready, add it to the buffer
+                result.body += d;
+                // data event listener exists
+                eventManager.data(d);
+                // emit to stream
+                eventManager.stream.write(d);
+            })
+                // completion listner
+                .on('end', () => {
+                // append parse json function to result body
+                result.json = jsonCallback => jsonCallback ? JSON_1.toJson(result.body, jsonCallback) : JSON_1.toJson(result.body);
+                // save headers
+                result.headers = res.headers;
+                // callback with result
+                requestCallback(result);
+            })
+                // error listener
+                .on('error', error => {
+                // reject
+                requestCallback(Object.assign(Object.assign({}, result), { error }));
+            });
             // is gzip, decompress gzip response first if yes
             if (((options === null || options === void 0 ? void 0 : options.gzip) !== undefined && (options === null || options === void 0 ? void 0 : options.gzip) === true) || isGzip === true) {
                 // get gzip
@@ -128,72 +160,20 @@ function Poke(host, options, callback) {
                 // pipe response to decompress
                 res.pipe(gunzip);
                 // handles data
-                gunzip
-                    // data listener
-                    .on('data', d => {
-                    // decompression chunk ready, add it to the buffer
-                    result.body = result.body || '';
-                    result.body += d;
-                    // data event listener exists
-                    eventManager.data(d);
-                    // emit to stream
-                    eventManager.stream.write(d);
-                })
-                    // completion listner
-                    .on('end', () => {
-                    // append parse json function to result body
-                    result.json = (jsonCallback) => JSON_1.toJson((result.body || ''), jsonCallback);
-                    // save headers
-                    result.headers = res.headers;
-                    // callback with result
-                    requestCallback(result);
-                })
-                    // error listener
-                    .on('error', error => {
-                    // set error
-                    result.error = error;
-                    // reject
-                    requestCallback(result);
-                });
+                prepareStream(gunzip);
             }
             // handles non-gzip compressed request
             else {
-                res
-                    // data listener
-                    .on('data', d => {
-                    result.body = result.body || '';
-                    result.body += d;
-                    // data event listener exists
-                    eventManager.data(d);
-                    // emit to stream
-                    eventManager.stream.write(d);
-                })
-                    // completion listener
-                    .on('end', () => {
-                    // append parse json function to result body
-                    result.json = (jsonCallback) => JSON_1.toJson((result.body || ''), jsonCallback);
-                    // save headers
-                    result.headers = res.headers;
-                    // callback with result
-                    requestCallback(result);
-                })
-                    // error listener
-                    .on('error', error => {
-                    // set error
-                    result.error = error;
-                    // reject
-                    requestCallback(result);
-                });
+                prepareStream(res);
             }
         });
         // error listener
         (_b = _return.req) === null || _b === void 0 ? void 0 : _b.on('error', error => {
-            // set error
-            result.error = error;
+            const error_result = Object.assign(Object.assign({}, result), { error });
             // reject
-            requestCallback(result);
+            requestCallback(error_result);
             // error event listener exists
-            eventManager.error(result);
+            eventManager.error(error_result);
         });
         // has body
         if ((options === null || options === void 0 ? void 0 : options.body) !== undefined && /^post|put|delete$/i.test(options.method || 'GET')) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,7 +68,7 @@ function Poke(host, options, callback) {
             // check request is fired on not
             if (requestFired === false) {
                 // start request
-                makeRequest(_ => {
+                makeRequest(() => {
                     // end stream
                     eventManager.stream.end();
                 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,8 @@ function Poke(host, options, callback) {
         // setup result container
         const result = {
             body: '',
-            json: jsonCallback => jsonCallback ? JSON_1.toJson('', jsonCallback) : JSON_1.toJson('')
+            // parse json function
+            json: jsonCallback => jsonCallback ? JSON_1.toJson(result.body, jsonCallback) : JSON_1.toJson(result.body)
         };
         // setup request payload
         const payload = {
@@ -144,8 +145,6 @@ function Poke(host, options, callback) {
             })
                 // completion listner
                 .on('end', () => {
-                // append parse json function to result body
-                result.json = jsonCallback => jsonCallback ? JSON_1.toJson(result.body, jsonCallback) : JSON_1.toJson(result.body);
                 // save headers
                 result.headers = res.headers;
                 // callback with result

--- a/lib/interfaces/PokeOption.d.ts
+++ b/lib/interfaces/PokeOption.d.ts
@@ -1,4 +1,4 @@
-export default interface PokeOption {
+export default interface PokeOption<Body> {
     method?: 'POST' | 'GET' | 'PUT' | 'DELETE' | 'PATCH' | 'OPTIONS' | 'HEAD' | 'CONNECT' | 'TRACE';
     path?: string;
     port?: number;
@@ -6,7 +6,7 @@ export default interface PokeOption {
     query?: {
         [key: string]: number | boolean | string | null;
     };
-    body?: unknown;
+    body?: Body;
     gzip?: boolean;
     username?: string;
     password?: string;

--- a/lib/interfaces/PokeResult.d.ts
+++ b/lib/interfaces/PokeResult.d.ts
@@ -1,14 +1,18 @@
 /// <reference types="node" />
 import { IncomingHttpHeaders } from 'http';
-export interface JSONCallback {
-    (error: Error | null, json: {
-        [propName: string]: any;
-    } | null): unknown;
+export interface JSONCallback<Result> {
+    (error: Error | null, json: Result | null): unknown;
 }
-export default interface PokeResult {
+export interface PokeSuccess<Result> {
     statusCode?: number;
-    error?: Error;
-    body?: string;
+    body: string;
     headers?: Headers | IncomingHttpHeaders;
-    json?: (jsonCallback?: JSONCallback) => void | Promise<unknown>;
+    json: (jsonCallback?: JSONCallback<Result>) => void | Promise<Result>;
 }
+export declare type PokeError<Result> = PokeSuccess<Result> & {
+    error: Error;
+};
+export declare type PokeResult<Result> = PokeSuccess<Result> | PokeError<Result>;
+export declare function isPokeSuccess<Result>(input: any): input is PokeSuccess<Result>;
+export declare function isPokeError<Result>(input: any): input is PokeError<Result>;
+export default PokeResult;

--- a/lib/interfaces/PokeResult.js
+++ b/lib/interfaces/PokeResult.js
@@ -1,2 +1,11 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.isPokeError = exports.isPokeSuccess = void 0;
+function isPokeSuccess(input) {
+    return input.error == undefined;
+}
+exports.isPokeSuccess = isPokeSuccess;
+function isPokeError(input) {
+    return input.error != undefined;
+}
+exports.isPokeError = isPokeError;

--- a/lib/interfaces/PokeReturn.d.ts
+++ b/lib/interfaces/PokeReturn.d.ts
@@ -7,6 +7,6 @@ export default interface PokeReturn<Result> {
     req?: http.ClientRequest;
     promise: () => Promise<PokeSuccess<Result>>;
     abort: () => void;
-    on: (eventName: 'data' | 'error' | 'response' | 'end', callback: (result?: any) => void) => PokeReturn<Result>;
+    on: (eventName: 'data' | 'error' | 'response' | 'end', callback: (result?: unknown) => void) => PokeReturn<Result>;
     pipe: (writableStream: WriteStream | ServerResponse) => void;
 }

--- a/lib/interfaces/PokeReturn.d.ts
+++ b/lib/interfaces/PokeReturn.d.ts
@@ -1,12 +1,12 @@
 /// <reference types="node" />
-import PokeResult from './PokeResult';
+import { PokeSuccess } from './PokeResult';
 import * as http from 'http';
 import { WriteStream } from 'fs';
 import { ServerResponse } from 'http';
-export default interface PokeReturn {
-    req: http.ClientRequest | undefined;
-    promise: () => Promise<PokeResult>;
+export default interface PokeReturn<Result> {
+    req?: http.ClientRequest;
+    promise: () => Promise<PokeSuccess<Result>>;
     abort: () => void;
-    on: (eventName: 'data' | 'error' | 'response' | 'end', callback: (result?: any) => void) => PokeReturn;
+    on: (eventName: 'data' | 'error' | 'response' | 'end', callback: (result?: any) => void) => PokeReturn<Result>;
     pipe: (writableStream: WriteStream | ServerResponse) => void;
 }

--- a/lib/interfaces/Protocol.d.ts
+++ b/lib/interfaces/Protocol.d.ts
@@ -1,0 +1,3 @@
+declare type Protocol = "http" | "https";
+export declare function isProtocol(input: any): input is Protocol;
+export {};

--- a/lib/interfaces/Protocol.d.ts
+++ b/lib/interfaces/Protocol.d.ts
@@ -1,3 +1,3 @@
-declare type Protocol = "http" | "https";
-export declare function isProtocol(input: any): input is Protocol;
+declare type Protocol = 'http' | 'https';
+export declare function isProtocol(input: string): input is Protocol;
 export {};

--- a/lib/interfaces/Protocol.js
+++ b/lib/interfaces/Protocol.js
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.isProtocol = void 0;
+function isProtocol(input) {
+    return /^https?/.test(input);
+}
+exports.isProtocol = isProtocol;

--- a/src/helpers/Event.ts
+++ b/src/helpers/Event.ts
@@ -1,12 +1,12 @@
 import { WriteStream } from 'fs'
 import { ServerResponse } from 'http'
-import PokeResult from '../interfaces/PokeResult'
+import { PokeError, PokeSuccess } from '../interfaces/PokeResult'
 
-interface EventManager {
+interface EventManager <Result>{
     set: (eventName:string, callback:(param?:unknown) => void) => void,
-    response: (result:PokeResult) => void,
+    response: (result:PokeSuccess<Result>) => void,
     end:() => void,
-    error: (result:PokeResult) => void,
+    error: (result:PokeError<Result>) => void,
     data: (chunk:string|unknown) => void,
     stream: {
         set: (writableStream:WriteStream|ServerResponse) => void,
@@ -15,11 +15,11 @@ interface EventManager {
     }
 }
 
-const Event = function () {
+const Event = function <Result>(): EventManager<Result> {
     // the place to stores those callbacks
     const callbacks = {}
     // return append callback methods and event callback methods
-    const manager:EventManager = {
+    return {
         // set 
         set: (eventName, callback) => {
             // valid event name and callback is a function
@@ -28,7 +28,7 @@ const Event = function () {
                 callbacks[eventName] = callback
             }
         },
-        response: (result:PokeResult) => {
+        response: (result) => {
             if(callbacks['response'] !== undefined) {
                 // return response
                 callbacks['response'](result)
@@ -40,7 +40,7 @@ const Event = function () {
                 callbacks['end']()
             }
         },
-        error: (result:PokeResult) => {
+        error: (result) => {
             if(callbacks['error'] !== undefined) {
                 // return response object with error
                 callbacks['error'](result)
@@ -72,7 +72,6 @@ const Event = function () {
             }
         }
     }
-    return manager
 }
 
 export default Event

--- a/src/helpers/JSON.ts
+++ b/src/helpers/JSON.ts
@@ -1,30 +1,27 @@
 import { JSONCallback } from '../interfaces/PokeResult'
 
-export function toJson (jsonString:string, callback?:JSONCallback):void|Promise<unknown> {
-    // is promise flag
-    const isPromise = callback === undefined
-    try {
+export function toJson <Result>(jsonString:string):Promise<Result>;
+export function toJson <Result>(jsonString:string, callback:JSONCallback<Result>):void
+export function toJson <Result>(jsonString:string, callback?:JSONCallback<Result>):void|Promise<Result> {
+    if (callback === undefined) {
+       try {
         // parse json
         const json = JSON.parse(jsonString)
-        // return a promise object
-        if(isPromise) {
-            // resolve with json
-            return Promise.resolve(json)
-        } 
-        // callback with error:null, result:json
-        else {
-            callback && callback(null, json)
-        }
-    } catch (error) {
-        // return a promise object
-        if(isPromise) {
-            // error occurred, reject promise
-            return Promise.reject(error)
-        } 
-        // callback with error:null, result:json
-        else {
-            callback && callback(error, null)
+        // resolve with json
+        return Promise.resolve(json)
+       } catch (error) {
+           // error occurred, reject promise
+           return Promise.reject(error)
+       }
+    } else {
+        try {
+            // parse json
+            const json = JSON.parse(jsonString)
+            // callback with error:null, result:json
+            callback(null, json)
+        } catch (error) {
+            // callback with error:null, result:json
+            callback(error, null)
         }
     }
 }
-

--- a/src/helpers/JSON.ts
+++ b/src/helpers/JSON.ts
@@ -4,15 +4,15 @@ export function toJson <Result>(jsonString:string):Promise<Result>;
 export function toJson <Result>(jsonString:string, callback:JSONCallback<Result>):void
 export function toJson <Result>(jsonString:string, callback?:JSONCallback<Result>):void|Promise<Result> {
     if (callback === undefined) {
-       try {
+        try {
         // parse json
-        const json = JSON.parse(jsonString)
-        // resolve with json
-        return Promise.resolve(json)
-       } catch (error) {
-           // error occurred, reject promise
-           return Promise.reject(error)
-       }
+            const json = JSON.parse(jsonString)
+            // resolve with json
+            return Promise.resolve(json)
+        } catch (error) {
+            // error occurred, reject promise
+            return Promise.reject(error)
+        }
     } else {
         try {
             // parse json

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { stringifyQuery } from './helpers/Query'
 import { toJson } from './helpers/JSON'
 import Event from './helpers/Event'
 
-function Poke (host:string, options?:PokeOption, callback?:(PokeResult) => void):PokeReturn {
+function Poke<Body>(host:string, options?:PokeOption<Body>, callback?:(pr: PokeResult) => void):PokeReturn {
 
     // the flag to indicate whether request is fired already
     let requestFired = false

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ function Poke<Body, Result>(host:string, options?:PokeOption<Body>, callback?:(p
             // check request is fired on not
             if(requestFired === false) {
                 // start request
-                makeRequest(_ => {
+                makeRequest(() => {
                     // end stream
                     eventManager.stream.end()
                 })
@@ -139,29 +139,29 @@ function Poke<Body, Result>(host:string, options?:PokeOption<Body>, callback?:(p
 
             const prepareStream = (stream: http.IncomingMessage | zlib.Gunzip) => stream
                 // data listener
-                    .on('data', d => {
-                        // decompression chunk ready, add it to the buffer
-                        result.body += d
-                        // data event listener exists
-                        eventManager.data(d)
-                        // emit to stream
-                        eventManager.stream.write(d)
-                    })
+                .on('data', d => {
+                    // decompression chunk ready, add it to the buffer
+                    result.body += d
+                    // data event listener exists
+                    eventManager.data(d)
+                    // emit to stream
+                    eventManager.stream.write(d)
+                })
                 // completion listner
-                    .on('end', () => {
+                .on('end', () => {
                     // append parse json function to result body
-                        result.json = jsonCallback =>
-                            jsonCallback? toJson(result.body, jsonCallback) : toJson(result.body)
+                    result.json = jsonCallback =>
+                        jsonCallback? toJson(result.body, jsonCallback) : toJson(result.body)
                         // save headers
-                        result.headers = res.headers
-                        // callback with result
-                        requestCallback(result)
-                    })
+                    result.headers = res.headers
+                    // callback with result
+                    requestCallback(result)
+                })
                 // error listener
-                    .on('error', error => {
-                        // reject
-                        requestCallback({...result, error})
-                    })
+                .on('error', error => {
+                    // reject
+                    requestCallback({...result, error})
+                })
 
             // is gzip, decompress gzip response first if yes
             if((options?.gzip !== undefined && options?.gzip === true) || isGzip === true) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import PokeResult, { isPokeError, isPokeSuccess, PokeSuccess } from './interface
 import { stringifyQuery } from './helpers/Query'
 import { toJson } from './helpers/JSON'
 import Event from './helpers/Event'
+import { isProtocol } from './interfaces/Protocol'
 
 function Poke<Body, Result>(host:string, options?:PokeOption<Body>, callback?:(pr: PokeResult<Result>) => void):PokeReturn<Result> {
 
@@ -85,9 +86,10 @@ function Poke<Body, Result>(host:string, options?:PokeOption<Body>, callback?:(p
         // get protocol
         const protocol = host.substr(0, host.indexOf(':'))
         // check protocol
-        if(!/^https?/.test(protocol)) {
+        if(!isProtocol(protocol)) {
             throw new Error('url must starts with http:// or https://')
         }
+
         // get hostname
         let hostname:string = host.split('://').pop() || ''
         // make sure hostname is valid
@@ -129,7 +131,7 @@ function Poke<Body, Result>(host:string, options?:PokeOption<Body>, callback?:(p
             }
         }
         // prepare request and save it to pokeReturn
-        _return.req = _http?.request(payload, res => {
+        _return.req = _http.request(payload, res => {
             // set status code
             result.statusCode = res.statusCode
             // does response header indicates that using gzip?

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ function Poke (host:string, options?:PokeOption, callback?:(PokeResult) => void)
 
     // declare PokeReturn
     const _return:PokeReturn = {
-        req: undefined,
         promise: () => new Promise<PokeResult>((resolve, reject) => {
             makeRequest(result => {
                 // callback based on error whether error exists

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,8 @@ function Poke<Body, Result>(host:string, options?:PokeOption<Body>, callback?:(p
         // setup result container
         const result:PokeSuccess<Result> = {
             body: '',
-            json: jsonCallback => jsonCallback? toJson('', jsonCallback) : toJson('')
+            // parse json function
+            json: jsonCallback => jsonCallback? toJson(result.body, jsonCallback) : toJson(result.body)
         }
         // setup request payload
         const payload = {
@@ -152,10 +153,7 @@ function Poke<Body, Result>(host:string, options?:PokeOption<Body>, callback?:(p
                 })
                 // completion listner
                 .on('end', () => {
-                    // append parse json function to result body
-                    result.json = jsonCallback =>
-                        jsonCallback? toJson(result.body, jsonCallback) : toJson(result.body)
-                        // save headers
+                    // save headers
                     result.headers = res.headers
                     // callback with result
                     requestCallback(result)

--- a/src/interfaces/PokeOption.ts
+++ b/src/interfaces/PokeOption.ts
@@ -1,10 +1,10 @@
-export default interface PokeOption {
+export default interface PokeOption<Body> {
     method? : 'POST'|'GET'|'PUT'|'DELETE'|'PATCH'|'OPTIONS'|'HEAD'|'CONNECT'|'TRACE',
     path? : string
     port? : number
     headers? : Headers
     query? : {[key:string]:number|boolean|string|null}
-    body? : unknown
+    body? : Body
     gzip? : boolean
     // for the convinience of Basic auth
     username? : string

--- a/src/interfaces/PokeResult.ts
+++ b/src/interfaces/PokeResult.ts
@@ -17,11 +17,11 @@ export type PokeError<Result> = PokeSuccess<Result> & {
 
 export type PokeResult<Result> = PokeSuccess<Result> | PokeError<Result>
 
-export function isPokeSuccess<Result>(input: any) : input is PokeSuccess<Result>{
+export function isPokeSuccess<Result>(input) : input is PokeSuccess<Result>{
     return input.error == undefined
 }
 
-export function isPokeError<Result>(input: any) : input is PokeError<Result>{
+export function isPokeError<Result>(input) : input is PokeError<Result>{
     return input.error != undefined
 }
 

--- a/src/interfaces/PokeResult.ts
+++ b/src/interfaces/PokeResult.ts
@@ -1,13 +1,28 @@
 import { IncomingHttpHeaders } from 'http'
 
-export interface JSONCallback {
-    (error:Error|null, json:{[propName:string]:any}|null): unknown
+export interface JSONCallback<Result> {
+    (error:Error | null, json: Result | null): unknown
 }
 
-export default interface PokeResult {
+export interface PokeSuccess<Result> {
     statusCode? : number
-    error? : Error
-    body? : string
+    body : string
     headers? : Headers|IncomingHttpHeaders
-    json? : (jsonCallback?:JSONCallback) => void|Promise<unknown>
+    json : (jsonCallback?:JSONCallback<Result>) => void | Promise<Result>
 }
+
+export type PokeError<Result> = PokeSuccess<Result> & {
+    error : Error
+}
+
+export type PokeResult<Result> = PokeSuccess<Result> | PokeError<Result>
+
+export function isPokeSuccess<Result>(input: any) : input is PokeSuccess<Result>{
+    return input.error == undefined
+}
+
+export function isPokeError<Result>(input: any) : input is PokeError<Result>{
+    return input.error != undefined
+}
+
+export default PokeResult

--- a/src/interfaces/PokeReturn.ts
+++ b/src/interfaces/PokeReturn.ts
@@ -10,7 +10,7 @@ export default interface PokeReturn<Result> {
     // abort request
     abort : () => void,
     // event listeners
-    on: (eventName:'data'|'error'|'response'|'end', callback:(result?:any) => void) => PokeReturn<Result>,
+    on: (eventName:'data'|'error'|'response'|'end', callback:(result?:unknown) => void) => PokeReturn<Result>,
     /* ----- stream ----- */
     pipe: (writableStream:WriteStream|ServerResponse) => void,
 }

--- a/src/interfaces/PokeReturn.ts
+++ b/src/interfaces/PokeReturn.ts
@@ -1,16 +1,16 @@
-import PokeResult from './PokeResult'
+import { PokeSuccess } from './PokeResult'
 import * as http from 'http'
 import { WriteStream } from 'fs'
 import { ServerResponse } from 'http'
 
 
-export default interface PokeReturn {
+export default interface PokeReturn<Result> {
     req?: http.ClientRequest,
-    promise : () => Promise<PokeResult>,
+    promise : () => Promise<PokeSuccess<Result>>,
     // abort request
     abort : () => void,
     // event listeners
-    on: (eventName:'data'|'error'|'response'|'end', callback:(result?:any) => void) => PokeReturn,
+    on: (eventName:'data'|'error'|'response'|'end', callback:(result?:any) => void) => PokeReturn<Result>,
     /* ----- stream ----- */
     pipe: (writableStream:WriteStream|ServerResponse) => void,
 }

--- a/src/interfaces/PokeReturn.ts
+++ b/src/interfaces/PokeReturn.ts
@@ -5,7 +5,7 @@ import { ServerResponse } from 'http'
 
 
 export default interface PokeReturn {
-    req: http.ClientRequest|undefined,
+    req?: http.ClientRequest,
     promise : () => Promise<PokeResult>,
     // abort request
     abort : () => void,

--- a/src/interfaces/Protocol.ts
+++ b/src/interfaces/Protocol.ts
@@ -1,0 +1,5 @@
+type Protocol = "http" | "https";
+
+export function isProtocol(input: any): input is Protocol {
+  return /^https?/.test(input);
+}

--- a/src/interfaces/Protocol.ts
+++ b/src/interfaces/Protocol.ts
@@ -1,5 +1,5 @@
-type Protocol = "http" | "https";
+type Protocol = 'http' | 'https';
 
-export function isProtocol(input: any): input is Protocol {
-  return /^https?/.test(input);
+export function isProtocol(input: string): input is Protocol {
+    return /^https?/.test(input)
 }


### PR DESCRIPTION
The original type is a little bit crippling to use if the user want more control.

Main changes:
1. PokeOption is now generic on Body(the request body).
2. Many types are now genreic on Result(the type of json that the api result)
3. PokeResult split up into PokeSuccess and PokeError types.
4. Added an Procotol type and typeguard for it.
5. PokeSuccess now always has body and json attribute(not optional)
6. Added EventCallbacksContainer type
7. Fixed bugs.