### PR TITLE
patch/type-fixes

### DIFF
--- a/src/helpers/Event.ts
+++ b/src/helpers/Event.ts
@@ -21,10 +21,10 @@ type EventCallbacksContainer = {
 
 interface EventManager {
     set: <Event extends CallbackEvent>(eventName: Event, callback: EventCallbacksContainer[Event]) => void,
-    response: EventCallbacksContainer['response'],
-    end: EventCallbacksContainer['end'],
-    error: EventCallbacksContainer['error'],
-    data: EventCallbacksContainer['data'],
+    response: NonNullable<EventCallbacksContainer['response']>,
+    end: NonNullable<EventCallbacksContainer['end']>,
+    error: NonNullable<EventCallbacksContainer['error']>,
+    data: NonNullable<EventCallbacksContainer['data']>,
     stream: {
         set: (writableStream: Stream) => void,
         write: (chunk:unknown) => void, // FIXME what is the type of chuck should be string?

--- a/src/helpers/Event.ts
+++ b/src/helpers/Event.ts
@@ -10,21 +10,21 @@ function isCallbackEvent(input:string): input is CallbackEvent {
 
 type Stream = WriteStream | ServerResponse
 
-type EventCallbacksContainer<Result> = {
+type EventCallbacksContainer = {
     [e in CallbackEvent | 'stream']? : 
         e extends 'data' ? (chunk:string) => void : 
-        e extends 'error' ? (result:PokeError<Result>) => void :
-        e extends 'response' ? (param?:PokeSuccess<Result>) => void : 
+        e extends 'error' ? (result:PokeError) => void :
+        e extends 'response' ? (param?:PokeSuccess) => void : 
         e extends 'end' ? () => void : 
         e extends 'stream' ? Stream : never
 }
 
-interface EventManager <Result>{
-    set: <Event extends CallbackEvent>(eventName: Event, callback: EventCallbacksContainer<Result>[Event]) => void,
-    response: EventCallbacksContainer<Result>['response'],
-    end: EventCallbacksContainer<Result>['end'],
-    error: EventCallbacksContainer<Result>['error'],
-    data: EventCallbacksContainer<Result>['data'],
+interface EventManager {
+    set: <Event extends CallbackEvent>(eventName: Event, callback: EventCallbacksContainer[Event]) => void,
+    response: EventCallbacksContainer['response'],
+    end: EventCallbacksContainer['end'],
+    error: EventCallbacksContainer['error'],
+    data: EventCallbacksContainer['data'],
     stream: {
         set: (writableStream: Stream) => void,
         write: (chunk:unknown) => void, // FIXME what is the type of chuck should be string?
@@ -32,9 +32,9 @@ interface EventManager <Result>{
     }
 }
 
-const initEventManager = function <Result>(): EventManager<Result> {
+const initEventManager = function (): EventManager {
     // the place to stores those callbacks
-    const callbacks: EventCallbacksContainer<Result> = {}
+    const callbacks: EventCallbacksContainer = {}
     // return append callback methods and event callback methods
     return {
         // set 

--- a/src/helpers/JSON.ts
+++ b/src/helpers/JSON.ts
@@ -2,28 +2,26 @@ export interface JSONCallback<Result> {
     (error:Error | null, json: Result | null): unknown
 }
 
-export function toJson <Result>(jsonString:string):Promise<Result>;
-export function toJson <Result>(jsonString:string, callback:JSONCallback<Result>):void
-export function toJson <Result>(jsonString:string, callback?:JSONCallback<Result>):void|Promise<Result> {
-    if (callback === undefined) {
-        try {
+export function toJsonWithCallback<Result>(jsonString:string, callback: JSONCallback<Result>): void {
+    try {
         // parse json
-            const json = JSON.parse(jsonString)
-            // resolve with json
-            return Promise.resolve(json)
-        } catch (error) {
-            // error occurred, reject promise
-            return Promise.reject(error)
-        }
-    } else {
-        try {
-            // parse json
-            const json = JSON.parse(jsonString)
-            // callback with error:null, result:json
-            callback(null, json)
-        } catch (error) {
-            // callback with error:null, result:json
-            callback(error, null)
-        }
+        const json = JSON.parse(jsonString)
+        // callback with error:null, result:json
+        callback(null, json)
+    } catch (error) {
+        // callback with error:null, result:json
+        callback(error, null)
+    }
+}
+
+export function toJson<Result>(jsonString:string): Promise<Result>  {
+    try {
+        // parse json
+        const json = JSON.parse(jsonString) as Result
+        // resolve with json
+        return Promise.resolve(json)
+    } catch (error) {
+        // error occurred, reject promise
+        return Promise.reject(error)
     }
 }

--- a/src/helpers/JSON.ts
+++ b/src/helpers/JSON.ts
@@ -1,4 +1,6 @@
-import { JSONCallback } from '../interfaces/PokeResult'
+export interface JSONCallback<Result> {
+    (error:Error | null, json: Result | null): unknown
+}
 
 export function toJson <Result>(jsonString:string):Promise<Result>;
 export function toJson <Result>(jsonString:string, callback:JSONCallback<Result>):void

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,11 +38,8 @@ function Poke<Body, Result>(host:string, options?:PokeOption<Body>, callback?:(p
             }
         },
         on: (eventName, callback) => {
-            // valid event name?
-            if(/^data|error|response|end$/.test(eventName)) {
-                // assign callback corresponse to event name
-                eventManager.set(eventName, callback)
-            }
+            // assign callback corresponse to event name
+            eventManager.set(eventName, callback)
             // check request is fired on not
             if(requestFired === false) {
                 // fire request

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,18 +46,15 @@ function Poke<Body>(host:string, options?:PokeOption<Body>, callback?:(pr: PokeR
                 makeRequest(result => {
                     // error exists AND error event listener exists
                     if (isPokeError(result)) {
-                        if (eventManager.error)
-                            // return response object
-                            eventManager.error(result)
+                        // return response object
+                        eventManager.error(result)
                     }
                     // no error
                     else {
                         // emit respnse
-                        if (eventManager.response)
-                            eventManager.response(result)
+                        eventManager.response(result)
                         // emit end event
-                        if (eventManager.end)
-                            eventManager.end()
+                        eventManager.end()
                     }
                     // end stream
                     eventManager.stream.end()
@@ -149,8 +146,7 @@ function Poke<Body>(host:string, options?:PokeOption<Body>, callback?:(pr: PokeR
                     // decompression chunk ready, add it to the buffer
                     result.body += d
                     // data event listener exists
-                    if (eventManager.data)
-                        eventManager.data(d)
+                    eventManager.data(d)
                     // emit to stream
                     eventManager.stream.write(d)
                 })
@@ -187,8 +183,7 @@ function Poke<Body>(host:string, options?:PokeOption<Body>, callback?:(pr: PokeR
             // reject
             requestCallback(error_result)
             // error event listener exists
-            if (eventManager.error)
-                eventManager.error(error_result)
+            eventManager.error(error_result)
         })
         // has body
         if(options?.body !== undefined && /^post|put|delete$/i.test(options.method || 'GET')) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import PokeOption from './interfaces/PokeOption'
 import PokeReturn from './interfaces/PokeReturn'
 import PokeResult, { isPokeError, PokeSuccess } from './interfaces/PokeResult'
 import { stringifyQuery } from './helpers/Query'
-import { JSONCallback, toJson } from './helpers/JSON'
+import { JSONCallback, toJson, toJsonWithCallback } from './helpers/JSON'
 import initEventManager from './helpers/Event'
 import { isProtocol } from './interfaces/Protocol'
 
@@ -116,7 +116,9 @@ function Poke<Body>(host:string, options?:PokeOption<Body>, callback?:(pr: PokeR
         const result:PokeSuccess = {
             body: '',
             // parse json function
-            json: <Result>(jsonCallback?: JSONCallback<Result>) => jsonCallback ? toJson<Result>(result.body, jsonCallback) : toJson<Result>(result.body)
+            json: <Result>(jsonCallback?: JSONCallback<Result>) => jsonCallback
+                ? toJsonWithCallback<Result>(result.body, jsonCallback)
+                : toJson<Result>(result.body)
         }
         // setup request payload
         const payload = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import * as http from 'http'
 import * as zlib from 'zlib'
 import PokeOption from './interfaces/PokeOption'
 import PokeReturn from './interfaces/PokeReturn'
-import PokeResult, { isPokeError, isPokeSuccess, PokeSuccess } from './interfaces/PokeResult'
+import PokeResult, { isPokeError, PokeSuccess } from './interfaces/PokeResult'
 import { stringifyQuery } from './helpers/Query'
 import { JSONCallback, toJson } from './helpers/JSON'
 import initEventManager from './helpers/Event'
@@ -27,7 +27,7 @@ function Poke<Body>(host:string, options?:PokeOption<Body>, callback?:(pr: PokeR
                 // fire request
                 makeRequest(result => {
                     // callback based on error whether error exists
-                    isPokeSuccess(result)? resolve(result): reject(result)
+                    !isPokeError(result)? resolve(result): reject(result)
                 })
             }
         }),
@@ -45,15 +45,16 @@ function Poke<Body>(host:string, options?:PokeOption<Body>, callback?:(pr: PokeR
                 // fire request
                 makeRequest(result => {
                     // error exists AND error event listener exists
-                        // return response object
-                        eventManager.error(result)
-                    if (isPokeError(result) && eventManager.error) {
+                    if (isPokeError(result)) {
+                        if (eventManager.error)
+                            // return response object
+                            eventManager.error(result)
                     }
                     // no error
                     else {
                         // emit respnse
                         if (eventManager.response)
-                            eventManager.response(result as PokeSuccess)
+                            eventManager.response(result)
                         // emit end event
                         if (eventManager.end)
                             eventManager.end()

--- a/src/interfaces/PokeResult.ts
+++ b/src/interfaces/PokeResult.ts
@@ -14,10 +14,6 @@ export type PokeError = PokeSuccess & {
 
 export type PokeResult = PokeSuccess | PokeError
 
-export function isPokeSuccess(input) : input is PokeSuccess{
-    return input.error == undefined
-}
-
 export function isPokeError(input) : input is PokeError{
     return input.error != undefined
 }

--- a/src/interfaces/PokeResult.ts
+++ b/src/interfaces/PokeResult.ts
@@ -1,27 +1,24 @@
 import { IncomingHttpHeaders } from 'http'
+import { JSONCallback } from '../helpers/JSON'
 
-export interface JSONCallback<Result> {
-    (error:Error | null, json: Result | null): unknown
-}
-
-export interface PokeSuccess<Result> {
+export interface PokeSuccess {
     statusCode? : number
     body : string
     headers? : Headers|IncomingHttpHeaders
-    json : (jsonCallback?:JSONCallback<Result>) => void | Promise<Result>
+    json : <Result>(jsonCallback?:JSONCallback<Result>) => void | Promise<Result>
 }
 
-export type PokeError<Result> = PokeSuccess<Result> & {
+export type PokeError = PokeSuccess & {
     error : Error
 }
 
-export type PokeResult<Result> = PokeSuccess<Result> | PokeError<Result>
+export type PokeResult = PokeSuccess | PokeError
 
-export function isPokeSuccess<Result>(input) : input is PokeSuccess<Result>{
+export function isPokeSuccess(input) : input is PokeSuccess{
     return input.error == undefined
 }
 
-export function isPokeError<Result>(input) : input is PokeError<Result>{
+export function isPokeError(input) : input is PokeError{
     return input.error != undefined
 }
 

--- a/src/interfaces/PokeReturn.ts
+++ b/src/interfaces/PokeReturn.ts
@@ -4,13 +4,13 @@ import { WriteStream } from 'fs'
 import { ServerResponse } from 'http'
 
 
-export default interface PokeReturn<Result> {
+export default interface PokeReturn {
     req?: http.ClientRequest,
-    promise : () => Promise<PokeSuccess<Result>>,
+    promise : () => Promise<PokeSuccess>,
     // abort request
     abort : () => void,
     // event listeners
-    on: (eventName:'data'|'error'|'response'|'end', callback:(result?:unknown) => void) => PokeReturn<Result>,
+    on: (eventName:'data'|'error'|'response'|'end', callback:(result?:unknown) => void) => PokeReturn,
     /* ----- stream ----- */
     pipe: (writableStream:WriteStream|ServerResponse) => void,
 }


### PR DESCRIPTION
Main changes:
1. Scope the "Result" generics to only the "json" extractor, instead of infecting the whole code base by associating it the "poke" request function.
2. Fixed the Event manager type.

Minor changes:
3. Removed some redundant checks on existence eventCallbacks(were checked two times both inside and outside of the event managers).
4. fixed some typeguards usage.
5. split the toJson function to into two to avoid the eye-hurting overloading function
